### PR TITLE
Removing version from closure and locale paths.

### DIFF
--- a/app/com/kinja/play/plugins/Closure.scala
+++ b/app/com/kinja/play/plugins/Closure.scala
@@ -77,7 +77,7 @@ class ClosurePlugin(app: Application) extends Plugin {
 
   def newEngine: ClosureEngine = assetPath match {
     // read templates from filesystem
-    case Some(rootDir) => ClosureEngine(app.mode, soyPaths, version, rootDir, modules)
+    case Some(rootDir) => ClosureEngine(app.mode, soyPaths, rootDir, modules)
     // read templates from jar
     case _ => ClosureEngine.apply(modules)
   }
@@ -417,7 +417,6 @@ object ClosureEngine {
   def apply(
     mode: Mode.Mode,
     soyPaths: List[String],
-    version: String,
     rootDir: String,
     modules: Seq[com.google.inject.Module]): ClosureEngine = mode match {
     case Mode.Dev => soyPaths match {
@@ -428,14 +427,14 @@ object ClosureEngine {
     case _ =>
       val templateDirs = soyPaths match {
         case sp: List[String] if sp.nonEmpty =>
-          sp.map(p => new File(rootDir + "/" + version + p + "/closure"))
-        case _ => List(new File(rootDir + "/" + version + "/closure"))
+          sp.map(p => new File(rootDir + "/" + p + "/closure"))
+        case _ => List(new File(rootDir + "/closure"))
       }
       val existingTemplateDirs = templateDirs.filter(_.exists)
       Logger("closureplugin").info("Checking template directory: " + templateDirs)
       if (existingTemplateDirs.nonEmpty) {
         Logger("closureplugin").info("Using '" + existingTemplateDirs + "' template directory")
-        val localeDir = new File(rootDir + "/" + version + "/locales")
+        val localeDir = new File(rootDir + "/locales")
         if (localeDir.exists) {
           Logger("closureplugin").info("Using '" + localeDir + "' locale directory")
           apply(existingTemplateDirs, Some(localeDir), modules = modules)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ import com.typesafe.sbt.SbtScalariform._
 object ApplicationBuild extends Build {
 
   val appName         = "play2-closure"
-  val appVersion      = "0.43-2.3.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+  val appVersion      = "0.44-2.3.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
   val localSettings = scalariformSettings ++ Seq(
     version := appVersion,


### PR DESCRIPTION
@kalmiz 

We are removing the `version` from the path used to access closure templates. The closure and locale files will now live in `/usr/local/bin/kinja-mantle/app`. This PR is designed to allow us to use these new locations.