### PR TITLE
Handling SoyMap underlying type change

### DIFF
--- a/app/com/kinja/play/plugins/Closure.scala
+++ b/app/com/kinja/play/plugins/Closure.scala
@@ -509,11 +509,8 @@ object Closure {
 
   def setVersion(value: String): Boolean = plugin.setVersion(value)
 
-  def render(template: String, data: Map[String, Any] = Map()): String =
-    plugin.api.render(template, data, Map[String, Any]())
-
-  def render(template: String, data: Map[String, Any], inject: Map[String, Any]): String =
-    plugin.api.render(template, data, inject)
+  def render(template: String): String =
+    plugin.api.render(template, new SoyMapData(), new SoyMapData())
 
   def render(template: String, data: SoyMapData): String =
     plugin.api.render(template, data, new SoyMapData())
@@ -528,10 +525,10 @@ object Closure {
     plugin.api.render(template, data.build, inject.build)
 
   def html(template: String, data: Map[String, Any] = Map()): Html =
-    Html(render(template, data, Map[String, Any]()))
+    Html(plugin.api.render(template, data, Map[String, Any]()))
 
   def html(template: String, data: Map[String, Any], inject: Map[String, Any]): Html =
-    Html(render(template, data, inject))
+    Html(plugin.api.render(template, data, inject))
 
   def html(template: String, data: SoyMapData): Html =
     Html(render(template, data, new SoyMapData))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,14 +8,14 @@ import com.typesafe.sbt.SbtScalariform._
 object ApplicationBuild extends Build {
 
   val appName         = "play2-closure"
-  val appVersion      = "0.49-2.3.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+  val appVersion      = "0.50-2.3.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
   val localSettings = scalariformSettings ++ Seq(
     version := appVersion,
     // Add your own project settings here
     libraryDependencies ++= Seq(
       ("com.google.template" % "soy" % "2012-12-21").exclude("asm", "asm"),
-      "com.kinja" %% "soy" % "0.4.4"),
+      "com.kinja" %% "soy" % "1.0.0"),
     resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content/groups/public/",
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     scalaVersion := "2.10.4",

--- a/test/com/kinja/play/plugins/ClosurePluginSpec.scala
+++ b/test/com/kinja/play/plugins/ClosurePluginSpec.scala
@@ -1,6 +1,7 @@
 // vim: sw=2 ts=2 softtabstop=2 expandtab :
 package com.kinja.play.plugins
 
+import com.kinja.soy.Soy
 import org.specs2.mutable._
 
 import play.api.test._
@@ -23,7 +24,7 @@ class ClosurePluginSpec extends Specification with TestApp {
   "Render a Long value" should {
     "equal '42'" in {
       running(app) {
-        Closure.render("closuretest.long", Map("long" -> 42L)) === "42"
+        Closure.render("closuretest.long", Soy.map("long" -> 42L)) === "42"
       }
     }
   }
@@ -31,7 +32,7 @@ class ClosurePluginSpec extends Specification with TestApp {
   "Render Boolean values" should {
     "equal 'true false'" in {
       running(app) {
-        Closure.render("closuretest.bool", Map("true" -> true, "nottrue" -> false)) === "true false"
+        Closure.render("closuretest.bool", Soy.map("true" -> true, "nottrue" -> false)) === "true false"
       }
     }
   }
@@ -41,7 +42,7 @@ class ClosurePluginSpec extends Specification with TestApp {
       running(app) {
         Closure.render(
           "closuretest.list",
-          Map("name" -> Some("Test list"), "list" -> List(1, "2", 3, 4, "5", 6))) === "Test list: 1, 2, 3, 4, 5, 6"
+          Soy.map("name" -> Some("Test list"), "list" -> Soy.list(1, "2", 3, 4, "5", 6))) === "Test list: 1, 2, 3, 4, 5, 6"
       }
     }
   }
@@ -51,27 +52,7 @@ class ClosurePluginSpec extends Specification with TestApp {
       running(app) {
         Closure.render(
           "closuretest.listInList",
-          Map("name" -> Some("Test list"), "list" -> List(List(1, "2", 3, 4L, 5, 6)))) === "Test list: 1, 2, 3, 4, 5, 6"
-      }
-    }
-  }
-
-  "Render a soy list test page" should {
-    "equal 'Test list: 1, 2, 3, 4, 6'" in {
-      running(app) {
-        Closure.render(
-          "closuretest.list",
-          Map("name" -> Some("Test list"), "list" -> new SoyListData(java.util.Arrays.asList(1, 2, 3, 4, 5, 6)))) === "Test list: 1, 2, 3, 4, 5, 6"
-      }
-    }
-  }
-
-  "Render a soy list in list test page" should {
-    "equal 'Test list: 1, 2, 3, 4, 6'" in {
-      running(app) {
-        Closure.render(
-          "closuretest.listInList",
-          Map("name" -> Some("Test list"), "list" -> List(new SoyListData(java.util.Arrays.asList(1, 2, 3, 4, 5, 6))))) === "Test list: 1, 2, 3, 4, 5, 6"
+          Soy.map("name" -> Some("Test list"), "list" -> Soy.list(Soy.list(1, "2", 3, 4L, 5, 6)))) === "Test list: 1, 2, 3, 4, 5, 6"
       }
     }
   }
@@ -81,27 +62,7 @@ class ClosurePluginSpec extends Specification with TestApp {
       running(app) {
         Closure.render(
           "closuretest.listInMap",
-          Map("name" -> Some("Test list"), "map" -> Map("items" -> List(1, "2", 3, 4L, 5, 6)))) === "Test list: 1, 2, 3, 4, 5, 6"
-      }
-    }
-  }
-
-  "Render a soy list in map test page" should {
-    "equal 'Test list: 1, 2, 3, 4, 6'" in {
-      running(app) {
-        Closure.render(
-          "closuretest.listInMap",
-          Map("name" -> Some("Test list"), "map" -> Map("items" -> new SoyListData(java.util.Arrays.asList(1, 2, 3, 4, 5, 6))))) === "Test list: 1, 2, 3, 4, 5, 6"
-      }
-    }
-  }
-
-  "Render a soy list in soy map test page" should {
-    "equal 'Test list: 1, 2, 3, 4, 6'" in {
-      running(app) {
-        Closure.render(
-          "closuretest.listInMap",
-          Map("name" -> Some("Test list"), "map" -> new SoyMapData("items", (new SoyListData(java.util.Arrays.asList(1, 2, 3, 4, 5, 6)))))) === "Test list: 1, 2, 3, 4, 5, 6"
+          Soy.map("name" -> Some("Test list"), "map" -> Soy.map("items" -> Soy.list(1, "2", 3, 4L, 5, 6)))) === "Test list: 1, 2, 3, 4, 5, 6"
       }
     }
   }
@@ -122,12 +83,12 @@ class ClosurePluginSpec extends Specification with TestApp {
   "Render an Option value" should {
     "equal 'None'" in {
       running(app) {
-        Closure.render("closuretest.option", Map("value" -> None)) === "None"
+        Closure.render("closuretest.option", Soy.map("value" -> Option.empty[String])) === "None"
       }
     }
     "equal 'Some'" in {
       running(app) {
-        Closure.render("closuretest.option", Map("value" -> Some("Some value"))) === "Some value"
+        Closure.render("closuretest.option", Soy.map("value" -> Some("Some value"))) === "Some value"
       }
     }
   }
@@ -136,8 +97,8 @@ class ClosurePluginSpec extends Specification with TestApp {
     "work" in {
       running(app) {
         Closure.render("closuretest.locale") === "Submit"
-        Closure.render("closuretest.locale", Map("locale" -> "hu_HU")) === "Hu Submit"
-        Closure.render("closuretest.locale", Map("locale" -> "es_ES")) === "es Submit"
+        Closure.render("closuretest.locale", Soy.map("locale" -> "hu_HU")) === "Hu Submit"
+        Closure.render("closuretest.locale", Soy.map("locale" -> "es_ES")) === "es Submit"
       }
     }
   }
@@ -145,7 +106,7 @@ class ClosurePluginSpec extends Specification with TestApp {
   "Inject" should {
     "work" in {
       running(app) {
-        Closure.render("closuretest.inject", Map[String, Any](), Map("foo" -> "bar")) === "bar"
+        Closure.render("closuretest.inject", Soy.map(), Soy.map("foo" -> "bar")) === "bar"
       }
     }
   }
@@ -153,7 +114,7 @@ class ClosurePluginSpec extends Specification with TestApp {
   "Empty delegate" should {
     "work" in {
       running(app) {
-        Closure.render("closuretest.option", Map("delegate" -> Set(), "value" -> Some("Some value"))) === "Some value"
+        Closure.render("closuretest.option", Soy.map("delegate" -> Soy.map(), "value" -> Some("Some value"))) === "Some value"
       }
     }
   }

--- a/test/com/kinja/soy/SoyRenderSpec.scala
+++ b/test/com/kinja/soy/SoyRenderSpec.scala
@@ -283,136 +283,136 @@ class SoyRenderSpec extends Specification with TestApp {
     }
   }
 
-  "Closure renderer with Map[String, Any] outer type" should {
+  "Closure renderer with Soy.map( outer type" should {
     "render SoyNull" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNull", Map[String, Any]("value" -> SoyNull))
+        val rendered = Closure.render("soyrender.valueNull", Soy.map("value" -> SoyNull))
         rendered must_== "Value is: NULL"
       }
     }
     "render SoyString(string)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueString", Map[String, Any]("value" -> SoyString("test string")))
+        val rendered = Closure.render("soyrender.valueString", Soy.map("value" -> SoyString("test string")))
         rendered must_== "Value is: test string"
       }
     }
     "render SoyString(null)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueString", Map[String, Any]("value" -> SoyString(null)))
+        val rendered = Closure.render("soyrender.valueString", Soy.map("value" -> SoyString(null)))
         rendered must_== "Value is: UNDEFINED"
       }
     }
     "render SoyBoolean(true)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueBoolean", Map[String, Any]("value" -> SoyBoolean(true)))
+        val rendered = Closure.render("soyrender.valueBoolean", Soy.map("value" -> SoyBoolean(true)))
         rendered must_== "Value is: TRUE"
       }
     }
     "render SoyBoolean(false)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueBoolean", Map[String, Any]("value" -> SoyBoolean(false)))
+        val rendered = Closure.render("soyrender.valueBoolean", Soy.map("value" -> SoyBoolean(false)))
         rendered must_== "Value is: FALSE"
       }
     }
     "render SoyInt(+int)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyInt(1984500239)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyInt(1984500239)))
         rendered must_== "Value is: 1984500239"
       }
     }
     "render SoyInt(0)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyInt(0)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyInt(0)))
         rendered must_== "Value is: 0"
       }
     }
     "render SoyInt(-int)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyInt(-98983423)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyInt(-98983423)))
         rendered must_== "Value is: -98983423"
       }
     }
     "render SoyFloat(+float)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyFloat(8329.5f)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyFloat(8329.5f)))
         rendered must_== "Value is: 8329.5"
       }
     }
     "render SoyFloat(0)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyFloat(0.0f)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyFloat(0.0f)))
         rendered must_== "Value is: 0.0"
       }
     }
     "render SoyFloat(-float)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyFloat(-9409.5f)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyFloat(-9409.5f)))
         rendered must_== "Value is: -9409.5"
       }
     }
     "render SoyDouble(+double)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyDouble(983.279)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyDouble(983.279)))
         rendered must_== "Value is: 983.279"
       }
     }
     "render SoyDouble(0)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyDouble(0.0)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyDouble(0.0)))
         rendered must_== "Value is: 0.0"
       }
     }
     "render SoyDouble(-double)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueNumber", Map[String, Any]("value" -> SoyDouble(-167.5982)))
+        val rendered = Closure.render("soyrender.valueNumber", Soy.map("value" -> SoyDouble(-167.5982)))
         rendered must_== "Value is: -167.5982"
       }
     }
     "render SoyList()" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> SoyList(Seq())))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> SoyList(Seq())))
         rendered must_== "List is: EMPTY"
       }
     }
     "render SoyList(int, int, ...)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> SoyList(Seq(SoyInt(1), SoyInt(2), SoyInt(3), SoyInt(4), SoyInt(5), SoyInt(6)))))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> SoyList(Seq(SoyInt(1), SoyInt(2), SoyInt(3), SoyInt(4), SoyInt(5), SoyInt(6)))))
         rendered must_== "List is: 1, 2, 3, 4, 5, 6"
       }
     }
     "render SoyList(string, string, ...)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> SoyList(Seq(SoyString("a"), SoyString("b"), SoyString("c")))))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> SoyList(Seq(SoyString("a"), SoyString("b"), SoyString("c")))))
         rendered must_== "List is: a, b, c"
       }
     }
     "render SoyList(string, int, float, double, null)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> SoyList(Seq(SoyString("a"), SoyInt(1), SoyFloat(2.0f), SoyDouble(3.0), SoyNull))))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> SoyList(Seq(SoyString("a"), SoyInt(1), SoyFloat(2.0f), SoyDouble(3.0), SoyNull))))
         rendered must_== "List is: a, 1, 2.0, 3.0, UNDEFINED"
       }
     }
     "render SoyList()" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> Soy.list()))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> Soy.list()))
         rendered must_== "List is: EMPTY"
       }
     }
     "render Soy.list(int, int, ...)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> Soy.list(1, 2, 3, 4, 5, 6)))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> Soy.list(1, 2, 3, 4, 5, 6)))
         rendered must_== "List is: 1, 2, 3, 4, 5, 6"
       }
     }
     "render Soy.list(string, string, ...)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> Soy.list("a", "b", "c")))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> Soy.list("a", "b", "c")))
         rendered must_== "List is: a, b, c"
       }
     }
     "render Soy.list(string, int, float, double, null)" in {
       running(app) {
-        val rendered = Closure.render("soyrender.valueList", Map[String, Any]("list" -> Soy.list("a", 1, 2.0f, 3.0, SoyNull)))
+        val rendered = Closure.render("soyrender.valueList", Soy.map("list" -> Soy.list("a", 1, 2.0f, 3.0, SoyNull)))
         rendered must_== "List is: a, 1, 2.0, 3.0, UNDEFINED"
       }
     }


### PR DESCRIPTION
### What does this PR do? How does it affect users?
As of [soy-0.5](https://github.com/gawkermedia/soy/pull/6) SoyMap becomes Map[String, Any] making the here deleted methods' signature ambiguous after erasure. Also fixing tests

### How should this be tested (feature switches, URLs, special user permissions)?
Code should compile and tests should succeed.
