### PR TITLE
Fix reading template files from the JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mappings in (Compile, packageBin) ++= {
 ```
 
 For alternative ways to provide the plugin with the template files (for example when deploying the
-templates separately from app), see the [Templates in production](#templates_in_production) section below.
+templates separately from app), see the [Templates in production](#templates-in-production) section below.
 
 ### Setting the locale
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ import com.typesafe.sbt.SbtScalariform._
 object ApplicationBuild extends Build {
 
   val appName         = "play2-closure"
-  val appVersion      = "0.55-2.3.9" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+  val appVersion      = "0.56-2.3.9" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
   val localSettings = scalariformSettings ++ Seq(
     version := appVersion,


### PR DESCRIPTION
### What does this PR do? How does it affect users?

Reading templates from the JAR file stopped working a long time ago because we used to read the template file names from `/closure_templates.txt` (I have no idea what generated that file). Now I fixed this by reading all JAR files on the class path and searching for `.soy` files in them. Reading the JAR file that belongs to `this.getClass` did not work since that's the play2-closure JAR, that's the reason for doing an extensive search.

I also updated the readme to reflect the truth.

### How should this be tested (feature switches, URLs, special user permissions)?

Start with a stub Play application and follow the readme to set up template rendering.

Create a test controller and try to make it render a template:

app/controllers/Test.scala:
```scala
package controllers

import play.api.mvc._
import com.kinja.play.plugins.Closure
import com.kinja.soy._

object Test extends Controller {
	def test = Action {
		val rendered = Closure.render("test.empty", Soy.map("hello" -> "world"))
		Ok(rendered).withHeaders(CONTENT_TYPE -> HTML)
	}
}
```

conf/routes:
```scala
GET /  controllers.Test.test
```

app/views/closure/test.soy:

```soy
{namespace test}

/**
 * Empty template
 */
{template .empty}
It works!
{/template}
```

If you can do this easily by following the readme then the PR is probably good to merge.

### Related Trello card, wiki page or blog posts

https://github.com/gawkermedia/play2-closure/issues/19